### PR TITLE
chore: updates health endpoint

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -25,5 +25,5 @@ springdoc.swagger-ui.operationsSorter=null
 server.forward-headers-strategy=framework
 
 # Actuator
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=when_authorized
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never


### PR DESCRIPTION
This pull request makes a small adjustment to the actuator endpoint configuration in the `application-prod.properties` file, limiting the exposure of management endpoints and restricting health details from being shown.

- Configuration changes:
  * Only the `health` actuator endpoint is exposed via the web, and health details are never shown, improving production security.